### PR TITLE
Cancel the event when scrolling on touch screen

### DIFF
--- a/jquery.longpress.js
+++ b/jquery.longpress.js
@@ -58,7 +58,12 @@
                         $.error('Optional callback for short press should be a function.');
                     }
                 }
-            };
+            }
+
+            // cancel long press event if the finger was moved (for touch screens)
+            function touchmove_callback(e) {
+                clearTimeout(timeout);
+            }
 
             // Browser Support
             $this.on('mousedown', mousedown_callback);
@@ -67,6 +72,7 @@
             // Mobile Support
             $this.on('touchstart', mousedown_callback);
             $this.on('touchend', mouseup_callback);
+            $this.on('touchmove', touchmove_callback);
         });
     };
 }(jQuery));


### PR DESCRIPTION
A long press event is fired during the continuous scrolling on mobile screen. It should be canceled when we receive "touchmove".
